### PR TITLE
fix: fix broken complete checklist link in menu

### DIFF
--- a/src/config/menus/apiMenu.ts
+++ b/src/config/menus/apiMenu.ts
@@ -187,8 +187,8 @@ export const apiMenu: MenuItemType[] = [
         badge: badges.activity,
       },
       {
-        title: 'Submit checklist response',
-        path: '/api-reference/mutations/submit-checklist-response',
+        title: 'Complete checklist',
+        path: '/api-reference/mutations/complete-checklist',
         badge: badges.activity,
       },
       {


### PR DESCRIPTION
Changes:
- link was pointing to page for `submit checklist response` when it is in fact called `complete checklist` now

Tested all other links on the page manually