### PR TITLE
refactor(score): clean up endpoint selector code and fix json parsing errors

### DIFF
--- a/src/components/ScoreExplorer/atoms/EndpointSelector.tsx
+++ b/src/components/ScoreExplorer/atoms/EndpointSelector.tsx
@@ -1,3 +1,5 @@
+import { ChangeEvent } from 'react'
+
 import {
   type Endpoint,
   type EndpointVersion,
@@ -19,6 +21,32 @@ export const EndpointSelector = ({
   selectedEndpointVersion,
   onChange,
 }: EndpointSelectorProps) => {
+
+  const handleEndpointChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const newEndpoint = endpoints.find(
+      (endpoint) => endpoint.id === e.target.value
+    )
+
+    if (newEndpoint) {
+      const latestEndpointVersion =
+        newEndpoint.versions.at(-1) || null
+      onChange(newEndpoint, latestEndpointVersion)
+    }
+  }
+
+  const handleEndpointVersionChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    if (selectedEndpoint) {
+      const newEndpointVersion = selectedEndpoint.versions.find(
+        (endpointVersion) =>
+          endpointVersion.version === e.target.value
+      )
+
+      if (newEndpointVersion) {
+        onChange(selectedEndpoint, newEndpointVersion)
+      } 
+    }
+  }
+
   return (
     <div className="">
       <div className="flex flex-row">
@@ -28,19 +56,7 @@ export const EndpointSelector = ({
             data-testid="endpoint"
             name="endpoint"
             value={selectedEndpoint?.id || ''}
-            onChange={(e) => {
-              const newEndpoint = endpoints.find(
-                (endpoint) => endpoint.id === e.target.value
-              )
-
-              if (newEndpoint) {
-                const latestEndpointVersion =
-                  newEndpoint.versions.at(-1) || null
-                onChange(newEndpoint, latestEndpointVersion)
-              } else {
-                onChange(null, null)
-              }
-            }}
+            onChange={handleEndpointChange}
           >
             <option disabled value="">
               Select endpoint
@@ -62,18 +78,7 @@ export const EndpointSelector = ({
                 selectedEndpointVersion?.version ||
                 selectedEndpoint.versions.at(-1)?.version
               }
-              onChange={(e) => {
-                const newEndpointVersion = selectedEndpoint.versions.find(
-                  (endpointVersion) =>
-                    endpointVersion.version === e.target.value
-                )
-
-                if (newEndpointVersion) {
-                  onChange(selectedEndpoint, newEndpointVersion)
-                } else {
-                  onChange(selectedEndpoint, null)
-                }
-              }}
+              onChange={handleEndpointVersionChange}
             >
               <option disabled value="">
                 Version

--- a/src/components/ScoreExplorer/hooks/useRequest/useRequest.tsx
+++ b/src/components/ScoreExplorer/hooks/useRequest/useRequest.tsx
@@ -44,9 +44,10 @@ export const useRequest = ({
     requestBodyParameters.length > 0
       ? Object.fromEntries(
           requestBodyParameters.map((parameter) => {
-            let value = parameter?.value || '{}'
+            let value
 
             if (parameter.type === 'object') {
+              value = parameter?.value || '{}'
               try {
                 value = JSON.parse(
                   typeof value === 'string' ? value.toString() : '{}'
@@ -55,6 +56,8 @@ export const useRequest = ({
                 value = 'Invalid calculation_input object'
                 console.log(e)
               }
+            } else {
+              value = parameter?.value || ''
             }
 
             return [parameter.name, value]

--- a/src/components/ScoreExplorer/hooks/useRequest/useRequest.tsx
+++ b/src/components/ScoreExplorer/hooks/useRequest/useRequest.tsx
@@ -44,12 +44,12 @@ export const useRequest = ({
     requestBodyParameters.length > 0
       ? Object.fromEntries(
           requestBodyParameters.map((parameter) => {
-            let value = parameter?.value || ''
+            let value = parameter?.value || '{}'
 
             if (parameter.type === 'object') {
               try {
                 value = JSON.parse(
-                  typeof value === 'string' ? value.toString() : ''
+                  typeof value === 'string' ? value.toString() : '{}'
                 )
               } catch (e) {
                 value = 'Invalid calculation_input object'


### PR DESCRIPTION
Changes:
- extract endpoint selector onChange handlers into separate functions and tidy up logic
- set fallback for useRequest parameter value to JSON parseable strings `'{}'`  to stop warnings 