### PR TITLE
Change description to match how SearchPatients works

### DIFF
--- a/content/awell-orchestration/api-reference/queries/search-patient.mdx
+++ b/content/awell-orchestration/api-reference/queries/search-patient.mdx
@@ -3,7 +3,7 @@ title: Search patients
 description: Search patients on patient code or national registry number
 ---
 
-Search for a patient in your tenant by patient code or national registry number, regardless of pathway or patient status. The search is done via exact-text match.
+Search for a patient in your tenant by patient code or national registry number. The search is done via an exact text match.
 
 ### Query
 

--- a/content/awell-orchestration/api-reference/queries/search-patient.mdx
+++ b/content/awell-orchestration/api-reference/queries/search-patient.mdx
@@ -3,7 +3,7 @@ title: Search patients
 description: Search patients on patient code or national registry number
 ---
 
-Search for one or more patients in your tenant by patient code or national registry number, regardless of pathway or patient status. The search is done via partial-text matching so multiple results may be returned for any given query.
+Search for a patient in your tenant by patient code or national registry number, regardless of pathway or patient status. The search is done via exact-text match.
 
 ### Query
 


### PR DESCRIPTION
At some point we changed the code to use exact match instead of LIKE, this updates the description to match how the code works