### PR TITLE
AST-4052 update session completed logic

### DIFF
--- a/pages/awell-orchestration/docs/activities/hosted-activity.tsx
+++ b/pages/awell-orchestration/docs/activities/hosted-activity.tsx
@@ -404,7 +404,7 @@ export default function HostedActivityPage() {
             {
               question: 'How long before a hosted activity session expires?',
               answer:
-                'By default, sessions expire after 15 minutes but the timer is reset after every completion of an activity. A session also expires when the pathway is completed.',
+                'By default, sessions expire after 15 minutes but the timer is reset after every completion of an activity. A session also expires when there are no pending activities left for stakeholder in the pathway.',
             },
             {
               question:

--- a/pages/awell-orchestration/docs/activities/hosted-pathway.tsx
+++ b/pages/awell-orchestration/docs/activities/hosted-pathway.tsx
@@ -339,7 +339,7 @@ export default function HostedPathwayPage() {
             {
               question: 'How long before a hosted pathway session expires?',
               answer:
-                'By default, sessions expire after 15 minutes but the timer is reset after every completion of an activity. A session also expires when the pathway is completed.',
+                'By default, sessions expire after 15 minutes but the timer is reset after every completion of an activity. A session also expires when there are no pending activities left in a pathway.',
             },
           ]}
         />


### PR DESCRIPTION
We slightly changed how Sessions get completed in Pathway/Activity sessions.

Since there can be non-blocking activities in a pathway which will complete the pathway without waiting for the user to read the activities. For example if there's a message activity in the last step, then user will never be able to read it.

So we changed the way how sessions get completed. Now the backend checks if there are no pending activities, then it ends the session.

@nckhell do you know other places where this info needs to be updated?

https://awellhealth.atlassian.net/browse/AST-4052