### PR TITLE
add type and value subfields in operand field in forms query

### DIFF
--- a/content/awell-orchestration/api-reference/queries/get-form.mdx
+++ b/content/awell-orchestration/api-reference/queries/get-form.mdx
@@ -40,7 +40,10 @@ query GetForm($id: String!) {
             reference
             reference_key
             operator
-            operand
+            operand {
+              type
+              value
+            }
           }
         }
       }

--- a/content/awell-orchestration/api-reference/queries/get-forms-in-pathway.mdx
+++ b/content/awell-orchestration/api-reference/queries/get-forms-in-pathway.mdx
@@ -61,7 +61,10 @@ query GetFormsForPublishedPathway(
             reference
             reference_key
             operator
-            operand
+            operand {
+              type
+              value
+            }
           }
         }
       }


### PR DESCRIPTION
The `operand` type is missing its destructured values. When I copy pasted the query and ran for my pathway, I got the following error:
```js
"Field \"operand\" of type \"Operand\" must have a selection of subfields. Did you mean \"operand { ... }\"?",
```