### PR TITLE
v0.20.4 Release Docs

### DIFF
--- a/content/awell-orchestration/api-reference/queries/get-pathway-activities.mdx
+++ b/content/awell-orchestration/api-reference/queries/get-pathway-activities.mdx
@@ -36,6 +36,10 @@ query GetPathwayActivities($pathway_id: String!) {
         type
         name
       }
+      # For form content
+      form {
+        ...Form
+      }
     }
   }
 }
@@ -134,6 +138,49 @@ The table below can help you with filtering activities for the right stakeholder
     </div>
   </div>
 </div>
+
+### Including Form Content in Form Activities
+
+To simplify obtaining the content of a form for a form activity, there are two options:
+- as with all actions, you can use the `activity.object.id` and the related getter query (e.g. GetForm, GetMessage) to fetch the content you need
+- expand this query by including the `form` field at the `activity` root (see `...Form` in the query above), along with the form fields you are interested in. The schema of a form is identical to what you would use in the [GetForm](/awell-orchestration/api-reference/queries/get-form) query:
+
+```graphql
+form {
+  id
+  title
+  questions {
+    id
+    title
+    dataPointValueType
+    questionType
+    options {
+      id
+      value
+      label
+    }
+    rule {
+      # visibility conditions of a question
+      boolean_operator
+      conditions {
+        id
+        reference
+        reference_key
+        operator
+        operand {
+          type
+          value
+        }
+      }
+    }
+  }
+}
+```
+
+For non-Form activities, this field will return `null`. Currently, the `form` field is only available on this activity query. 
+
+**Example:**<br/>
+If you'd like to get all pending activities for the patient, you can filter the activities array by `activity.indirect_object.type === PATIENT`.
 
 ## Examples
 

--- a/content/awell-orchestration/developer-tools/changelog/1_20_4.mdx
+++ b/content/awell-orchestration/developer-tools/changelog/1_20_4.mdx
@@ -1,0 +1,58 @@
+---
+title: 1.20.4
+description: Changelog for release v1.20.4
+releaseDate: '2023-1-30'
+---
+
+## Added
+
+### Added `form` field to GetPathwayActivities query
+
+It's now possible to additionally query for form content on form activities when fetching all activities for a care flow.
+
+```graphql
+query GetPathwayActivities($pathway_id: String!) {
+  pathwayActivities(pathway_id: $pathway_id) {
+    success
+    activities {
+      object {
+        # previously you needed this id to get a form in a separate query
+        id
+        type
+        name
+      }
+      # ...now you can just get the form here
+      form {
+        id
+        title
+        questions {
+            id
+            title
+            dataPointValueType
+            questionType
+            options {
+            id
+            value
+            label
+            }
+            rule {
+                boolean_operator
+                conditions {
+                    id
+                    reference
+                    reference_key
+                    operator
+                    operand {
+                    type
+                    value
+                    }
+                }
+            }
+        }
+      }
+    }
+  }
+}
+```
+
+With this change, when fetching the activities of a pathway with the intention to display form content, you no longer need to make a separate query `GetForm` after. You can see the details of this query [here](/awell-orchestration/api-reference/queries/get-pathway-activities).

--- a/pages/awell-orchestration/developer-tools/changelog/index.tsx
+++ b/pages/awell-orchestration/developer-tools/changelog/index.tsx
@@ -54,26 +54,26 @@ export default function ChangelogPage({ releases }: ChangelogPageProps) {
       </div>
       <div className="grid gap-3 sm:gap-6 mx-auto grid-cols-2 sm:grid-cols-3">
         {releases.map((release) => (
-          <div
-            key={release.slug}
-            className="p-6 w-full bg-white rounded-lg border border-gray-200 shadow-md dark:bg-gray-800 dark:border-gray-700"
-          >
-            <a href="#">
+          <a
+            href={`changelog/${release.slug}`}
+            key={release.slug} >
+            <div
+              className="p-6 w-full bg-white rounded-lg border border-gray-200 shadow-md dark:bg-gray-800 dark:border-gray-700"
+            >
               <h5 className="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
                 v{release.frontMatter.title}
               </h5>
-            </a>
-            <p className="mb-3 font-normal text-gray-700 dark:text-gray-400">
-              Released on{' '}
-              {format(new Date(release.frontMatter.releaseDate), 'MMMM d, y')}
-            </p>
-            <a
-              href={`changelog/${release.slug}`}
-              className="inline-flex items-center py-2 px-3 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
-            >
-              Read more
-            </a>
-          </div>
+              <p className="mb-3 font-normal text-gray-700 dark:text-gray-400">
+                Released on{' '}
+                {format(new Date(release.frontMatter.releaseDate), 'MMMM d, y')}
+              </p>
+              <div
+                className="inline-flex items-center py-2 px-3 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
+              >
+                Read more
+              </div>
+            </div>
+          </a>
         ))}
       </div>
       <div className="mt-12 max-w-3xl mx-auto xl:max-w-none xl:ml-0 xl:mr-[15.5rem] xl:pr-16">
@@ -93,8 +93,8 @@ export const getStaticProps: GetStaticProps = async () => {
     return a.frontMatter.releaseDate < b.frontMatter.releaseDate
       ? 1
       : a.frontMatter.releaseDate > b.frontMatter.releaseDate
-      ? -1
-      : 0
+        ? -1
+        : 0
   })
 
   return {

--- a/src/types/generated/api.types.ts
+++ b/src/types/generated/api.types.ts
@@ -11,7 +11,6 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
-  /** Safe date scalar that can serialize string or date */
   SafeDate: any;
 };
 


### PR DESCRIPTION
**Changes:**
- update to GetPathwayActivities docs to explain additional form field
- new change log page for v1.20.4
- made the whole change log card clickable, sorry nick, i know there's a read more button but it was bugging me it's a card you should always be able to click a card if there's only one action or link on it