### PR TITLE
AST-4906: Create uniformity on how languages are handled in our system

### DIFF
--- a/content/awell-orchestration/api-reference/mutations/start-hosted-activity-session.mdx
+++ b/content/awell-orchestration/api-reference/mutations/start-hosted-activity-session.mdx
@@ -49,7 +49,7 @@ The `success_url` and `cancel_url` specify where the stakeholder should be redir
     "stakeholder_id": "{{STAKEHOLDER_ID}}",
     "success_url": "https://yourdomain.com/success.html",
     "cancel_url": "https://yourdomain.com/cancel.html",
-    "language": "ENGLISH"
+    "language": "en"
   }
 }
 `}
@@ -62,34 +62,15 @@ You can specify the language you'd like the hosted pages app to be loaded in. If
 
 **Supported languages:**
 
-<div className="table-wrapper">
-  <table>
-    <thead>
-      <tr>
-        <th>Language</th>
-        <th>Value</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>English</td>
-        <td>ENGLISH</td>
-      </tr>
-      <tr>
-        <td>Dutch</td>
-        <td>DUTCH</td>
-      </tr>
-      <tr>
-        <td>French</td>
-        <td>FRENCH</td>
-      </tr>
-      <tr>
-        <td>Estonian</td>
-        <td>ESTONIAN</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
+Languages should be passed as an [ISO 639-1 shortcode](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
+
+```json
+{
+  "input": {
+    "language": "nl" | "en" | "de" | "et",
+  }
+}
+```
 
 <br />
 


### PR DESCRIPTION
<h2 data-renderer-start-pos="1" style="margin: 0px; padding: 0px; font-style: normal; color: rgb(23, 43, 77); letter-spacing: -0.008em; font-size: 1.42857em; line-height: 1.2; font-weight: var(--ds-font-weight-medium, 500); text-transform: none; font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; text-indent: 0px; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgba(235, 236, 240, 0.98); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Current state:</h2><div class="pm-table-container " data-layout="default" style="margin: 0px auto 16px; padding: 0px; position: relative; box-sizing: border-box; clear: both; z-index: 0; transition: all 0.1s linear 0s; display: flex; color: rgb(23, 43, 77); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgba(235, 236, 240, 0.98); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; width: inherit;"><div class="pm-table-wrapper" style="margin: 0px; padding: 0px; overflow-x: auto;">

Mutation | Property | Possible Values
-- | -- | --
updatePatient | preferred_language | en, nl, fr, et
createPatient | preferred_language | en, nl, fr, et
startHostedActivitySession | language | ENGLISH, DUTCH, FRENCH, ESTONIAN
startHostedPathwaySession | language | ENGLISH, DUTCH, FRENCH, ESTONIAN

</div></div>

<h2 data-renderer-start-pos="341" style="margin: 1.8em 0px 0px; padding: 0px; font-style: normal; color: rgb(23, 43, 77); letter-spacing: -0.008em; font-size: 1.42857em; line-height: 1.2; font-weight: var(--ds-font-weight-medium, 500); text-transform: none; font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; text-indent: 0px; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(235, 236, 240); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Updated state:</h2><div class="pm-table-container " data-layout="default" style="margin: 0px auto 16px; padding: 0px; position: relative; box-sizing: border-box; clear: both; z-index: 0; transition: all 0.1s linear 0s; display: flex; color: rgb(23, 43, 77); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(235, 236, 240); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; width: inherit;"><div class="pm-table-wrapper" style="margin: 0px; padding: 0px; overflow-x: auto;">

Mutation | Property | Possible Values
-- | -- | --
updatePatient | preferred_language | en, nl, fr, et
createPatient | preferred_language | en, nl, fr, et
startHostedActivitySession | language | en, nl, fr, et
startHostedPathwaySession | language | en, nl, fr, et

</div></div>